### PR TITLE
reward epoch configuration endpoint

### DIFF
--- a/apps/ftso-data-provider/src/dto/data-provider-responses.dto.ts
+++ b/apps/ftso-data-provider/src/dto/data-provider-responses.dto.ts
@@ -1,5 +1,6 @@
 // PDP (Protocol Data Provider) Response
 
+import { RewardEpoch } from "../../../../libs/ftso-core/src/RewardEpoch";
 import { AbiDataInput } from "../../../../libs/ftso-core/src/utils/ABICache";
 import { FeedResultWithProof, TreeResult } from "../../../../libs/ftso-core/src/utils/MerkleTreeStructs";
 import { MedianCalculationResult } from "../../../../libs/ftso-core/src/voting-types";
@@ -59,6 +60,25 @@ export type ExternalMedianResponse =
   | ExternalMedianResponseOk
   | ExternalMedianResponseNotAvailable
   | ExternalMedianResponseTooEarly;
+
+interface ExternalRewardEpochResponseOk {
+  status: ExternalResponseStatusEnum.OK;
+  rewardEpochId: number;
+  rewardEpochFeedConfiguration: RewardEpoch;
+}
+
+interface ExternalRewardEpochResponseNotAvailable {
+  status: ExternalResponseStatusEnum.NOT_AVAILABLE;
+}
+
+interface ExternalRewardEpochResponseTooEarly {
+  status: ExternalResponseStatusEnum.TOO_EARLY;
+}
+
+export type ExternalRewardEpochResponse =
+  | ExternalRewardEpochResponseOk
+  | ExternalRewardEpochResponseNotAvailable
+  | ExternalRewardEpochResponseTooEarly;
 
 export interface JSONAbiDefinition {
   abiName: string;

--- a/apps/ftso-data-provider/src/ftso-data-provider.controller.ts
+++ b/apps/ftso-data-provider/src/ftso-data-provider.controller.ts
@@ -18,6 +18,7 @@ import {
   ExternalMedianResponse,
   ExternalResponse,
   ExternalResponseStatusEnum,
+  ExternalRewardEpochResponse,
   PDPResponse,
   PDPResponseStatusEnum,
 } from "./dto/data-provider-responses.dto";
@@ -174,6 +175,20 @@ export class FtsoDataProviderController implements BeforeApplicationShutdown {
       status: data ? ExternalResponseStatusEnum.OK : ExternalResponseStatusEnum.NOT_AVAILABLE,
       votingRoundId,
       medianData: data,
+    };
+  }
+
+  @ApiTags(ApiTagsEnum.EXTERNAL)
+  @Get("rewardEpochFeedConfiguration/:votingRoundId")
+  async rewardEpochConfiguration(
+    @Param("votingRoundId", ParseIntPipe) votingRoundId: number
+  ): Promise<ExternalRewardEpochResponse> {
+    const data = await this.ftsoDataProviderService.getRewardEpoch(votingRoundId);
+
+    return {
+      status: data ? ExternalResponseStatusEnum.OK : ExternalResponseStatusEnum.NOT_AVAILABLE,
+      rewardEpochId: data.rewardEpochId,
+      rewardEpochFeedConfiguration: data,
     };
   }
 

--- a/apps/ftso-data-provider/src/ftso-data-provider.service.ts
+++ b/apps/ftso-data-provider/src/ftso-data-provider.service.ts
@@ -237,6 +237,12 @@ export class FtsoDataProviderService {
     ];
   }
 
+  async getRewardEpoch(votingRoundId: number): Promise<RewardEpoch> {
+    const rewardEpoch = await this.rewardEpochManager.getRewardEpochForVotingEpochId(votingRoundId);
+
+    return rewardEpoch;
+  }
+
   // Internal methods
 
   private async getFeedValuesForEpoch(votingRoundId: number, supportedFeeds: Feed[]): Promise<IRevealData> {


### PR DESCRIPTION
This PR adds and endpoint to GET the reward epoch configuration for a given votingRoundId.
It leverages existing functions in the codebase and is intended to facilitate data access for other programs used by the data provider, in my use case I specifically want to ease the dynamic updating and processing of new data feeds in the FTSO in the rest of my system.